### PR TITLE
fix: compare assets when update injected ethereum for rsk and set to …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liquality-wallet",
-  "version": "0.14.0",
+  "version": "0.13.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liquality-wallet",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liquality-wallet",
-  "version": "0.14.0",
+  "version": "0.13.2",
   "private": true,
   "license": "MIT",
   "author": "Liquality <info@liquality.io>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "liquality-wallet",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "private": true,
   "license": "MIT",
   "author": "Liquality <info@liquality.io>",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.13.1",
+  "version": "0.14.0",
   "name": "Liquality Wallet",
   "description": "Secure multi-crypto wallet with built-in Atomic Swaps!",
   "homepage_url": "https://liquality.io",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "version": "0.14.0",
+  "version": "0.13.2",
   "name": "Liquality Wallet",
   "description": "Secure multi-crypto wallet with built-in Atomic Swaps!",
   "homepage_url": "https://liquality.io",

--- a/src/store/migrations.js
+++ b/src/store/migrations.js
@@ -35,6 +35,17 @@ const migrations = [
       }
       return { ...state, customTokens }
     }
+  },
+  { // Fix for RSK token injected asset
+    version: 4,
+    migrate: async (state) => {
+      if (state.injectEthereumAsset === 'RSK') {
+        const injectEthereumAsset = 'RBTC'
+        return { ...state, injectEthereumAsset }
+      }
+
+      return { ...state }
+    }
   }
 ]
 

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -64,6 +64,10 @@ export default {
       else this.disableEthereumInjection()
     },
     updateInjectEthereumAsset (asset) {
+      // Update back to RBTC as asset
+      if (asset === 'RSK') {
+        asset = 'RBTC'
+      }
       this.setEthereumInjectionAsset({ asset })
     }
   }


### PR DESCRIPTION
This change fix a bug in the settings screen, when the user choose RSk in the dropdown we save the vale as is and not with the asset as should be, in this case RBTC, we apply the following fix when the user switch to RSk:

-  Compare asset and set back to RBTC when change to RSK in the settings screen