### PR TITLE
Fix link in README.md (minor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Liquality Wallet <img align="right" src="https://raw.githubusercontent.com/liquality/chainabstractionlayer/master/liquality-logo.png" height="80px" />
 
 ## Getting started
-- Install NVM [https://github.com/nvm-sh/nvm#installing-and-updating]()
+- Install NVM https://github.com/nvm-sh/nvm#installing-and-updating
 - Go to this folder repo and run `nvm use` to takes the right version for node (install if you need it)
 
 ## Project setup


### PR DESCRIPTION
My understanding is that markdown doesn't require special syntax if the full link is used. The current link is broken.