### PR TITLE
Retrieve fiat rates on selection in Swap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "liquality-wallet",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/background.js
+++ b/src/background.js
@@ -29,7 +29,7 @@ store.subscribe(async ({ type, payload }, state) => {
       store.dispatch('checkAnalyticsOptIn')
       store.dispatch('initializeAddresses', { network: state.activeNetwork, walletId: state.activeWalletId })
       store.dispatch('updateBalances', { network: state.activeNetwork, walletId: state.activeWalletId })
-      store.dispatch('updateFiatRates')
+      store.dispatch('updateFiatRates', { assets: store.getters.allNetworkAssets })
       store.dispatch('updateMarketData', { network: state.activeNetwork })
       store.dispatch('checkPendingActions', { walletId: state.activeWalletId })
 
@@ -42,13 +42,13 @@ store.subscribe(async ({ type, payload }, state) => {
       )
 
       asyncLoop(
-        () => store.dispatch('updateFiatRates'),
-        () => random(400000, 600000)
+        () => store.dispatch('updateFiatRates', { assets: Object.keys(state.fiatRates) }),
+        () => random(40000, 60000)
       )
 
       asyncLoop(
         () => store.dispatch('updateMarketData', { network: state.activeNetwork }),
-        () => random(400000, 600000)
+        () => random(40000, 60000)
       )
 
       break

--- a/src/store/actions/enableAssets.js
+++ b/src/store/actions/enableAssets.js
@@ -2,7 +2,7 @@ import cryptoassets from '@/utils/cryptoassets'
 import { accountCreator, getNextAccountColor } from '@/utils/accounts'
 import { chains } from '@liquality/cryptoassets'
 
-export const enableAssets = async ({ state, commit, dispatch }, { network, walletId, assets }) => {
+export const enableAssets = async ({ state, commit, dispatch, getters }, { network, walletId, assets }) => {
   commit('ENABLE_ASSETS', { network, walletId, assets })
   const accounts = state.accounts[walletId]?.[network] || []
 
@@ -44,6 +44,6 @@ export const enableAssets = async ({ state, commit, dispatch }, { network, walle
       await dispatch('updateAccountBalance', { network, walletId, accountId })
     }
   })
-  dispatch('updateFiatRates')
+  dispatch('updateFiatRates', { assets: getters.allNetworkAssets })
   dispatch('updateMarketData', { network })
 }

--- a/src/store/actions/updateFiatRates.js
+++ b/src/store/actions/updateFiatRates.js
@@ -1,7 +1,6 @@
 import { getPrices } from '../utils'
 
 export const updateFiatRates = async ({ commit }, { assets }) => {
-  console.log('updating fiat rates', assets)
   const fiatRates = await getPrices(assets, 'usd')
 
   commit('UPDATE_FIAT_RATES', { fiatRates })

--- a/src/store/actions/updateFiatRates.js
+++ b/src/store/actions/updateFiatRates.js
@@ -1,10 +1,7 @@
-import { Networks, getPrices } from '../utils'
-import { uniq } from 'lodash-es'
+import { getPrices } from '../utils'
 
-export const updateFiatRates = async ({ state, commit }) => {
-  const assets = Networks.reduce((result, network) => {
-    return uniq(result.concat(state.enabledAssets[network][state.activeWalletId]))
-  }, [])
+export const updateFiatRates = async ({ commit }, { assets }) => {
+  console.log('updating fiat rates', assets)
   const fiatRates = await getPrices(assets, 'usd')
 
   commit('UPDATE_FIAT_RATES', { fiatRates })

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -4,6 +4,8 @@ import { createSwapProvider } from './factory/swapProvider'
 import { Object } from 'core-js'
 import BN from 'bignumber.js'
 import { cryptoToFiat } from '@/utils/coinFormatter'
+import { Networks } from './utils'
+import { uniq } from 'lodash-es'
 
 const clientCache = {}
 const swapProviderCache = {}
@@ -96,6 +98,11 @@ export default {
   networkAssets (state) {
     const { enabledAssets, activeNetwork, activeWalletId } = state
     return enabledAssets[activeNetwork][activeWalletId]
+  },
+  allNetworkAssets (state) {
+    return Networks.reduce((result, network) => {
+      return uniq(result.concat(state.enabledAssets[network][state.activeWalletId]))
+    }, [])
   },
   activity (state) {
     const { history, activeNetwork, activeWalletId } = state

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -98,7 +98,7 @@ export default {
     Vue.set(state.fees[network][walletId], asset, fees)
   },
   UPDATE_FIAT_RATES (state, { fiatRates }) {
-    state.fiatRates = fiatRates
+    state.fiatRates = Object.assign({}, state.fiatRates, fiatRates)
   },
   UPDATE_MARKET_DATA (state, { network, marketData }) {
     Vue.set(state.marketData, network, marketData)

--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -660,7 +660,8 @@ export default {
       'getQuotes',
       'updateFees',
       'newSwap',
-      'trackAnalytics'
+      'trackAnalytics',
+      'updateFiatRates'
     ]),
     shortenAddress,
     dpUI,
@@ -702,12 +703,14 @@ export default {
 
       this.resetFees()
       this.updateQuotes()
+      this.updateFiatRates({ assets: [toAsset] })
     },
     setFromAsset (asset) {
       this.asset = asset
       this.sendAmount = dpUI(this.defaultAmount)
       this.resetFees()
       this.updateQuotes()
+      this.updateFiatRates({ assets: [asset] })
     },
     async _updateSwapFees (max) {
       if (!this.selectedQuote) return


### PR DESCRIPTION
Also overrides the fiat rates instead of simply resetting based on response. This preserves any existing fiat rates

## What?

Fiat rates were not retrieved for assets that are not preset in the wallet. 
Selecting a unknown ERC20 in swap would show wrong fiat price

#Notion/ Trello

https://www.notion.so/ERC20-Providers-Broken-8529a717fbeb4b90b32514a8066e0f69

## Why?

## How?

## Testing?
- [ ] Run tests locally

## Screenshots (optional)
0

## Anything Else?
