### PR TITLE
Swap: do not count fee in receive when not required

### DIFF
--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -191,12 +191,12 @@
               class="d-flex align-items-center justify-content-between my-0 py-0"
             >
               <div class="confirm-value" id="receive_swap_confirm_value" :style="getAssetColorStyle(toAsset)">
-                {{ receiveAmount }} {{ toAsset }}
+                {{ dpUI(receiveAmount) }} {{ toAsset }}
               </div>
               <div class="details-text" id="receive_swap_amount_fiat">{{ '$' + formatFiat(receiveAmountFiat) }}</div>
             </div>
           </div>
-          <div class="detail-group">
+          <div class="detail-group" v-if="receiveFeeRequired">
             <label class="text-muted">Network Fee</label>
             <div
               class="d-flex align-items-center justify-content-between my-0 py-0"
@@ -217,8 +217,8 @@
             <label class="text-muted">Amount - Fees</label>
             <div class="d-flex align-items-center justify-content-between mt-0">
               <div class="font-weight-bold" id="swap_receive_amount_fee_value">
-                <span v-if="toAsset === toAssetChain">
-                  {{ receiveAmountSameAsset }} {{ toAssetChain }}
+                <span v-if="toAsset === toAssetChain || !receiveFeeRequired">
+                  {{ receiveAmountSameAsset }} {{ toAsset }}
                 </span>
                 <span v-else>
                   {{ receiveAmount }} {{ toAsset }} -
@@ -555,6 +555,7 @@ export default {
       return fee || BN(0)
     },
     toSwapFee () {
+      if (!this.receiveFeeRequired) return BN(0)
       const selectedSpeed = this.selectedFee[this.toAssetChain]
       const fee = this.amountOption === 'max' ? this.maxSwapFees[this.toAssetChain]?.[selectedSpeed] : this.swapFees[this.toAssetChain]?.[selectedSpeed]
       return fee || BN(0)
@@ -563,6 +564,9 @@ export default {
       const selectedSpeed = this.selectedFee[this.assetChain]
       const fee = this.maxSwapFees[this.assetChain]?.[selectedSpeed]
       return fee ? currencyToUnit(cryptoassets[this.assetChain], fee) : BN(0)
+    },
+    receiveFeeRequired () {
+      return this.selectedQuoteProvider.toTxType
     },
     available () {
       if (!this.networkWalletBalances) return BN(0)
@@ -880,7 +884,7 @@ export default {
           ].fee
           : undefined
 
-        const toFee = this.availableFees.has(this.toAssetChain)
+        const toFee = this.receiveFeeRequired && this.availableFees.has(this.toAssetChain)
           ? this.getAssetFees(this.toAssetChain)[
             this.selectedFee[this.toAssetChain]
           ].fee

--- a/tests/integration/swipe_testnet.spec.js
+++ b/tests/integration/swipe_testnet.spec.js
@@ -193,19 +193,13 @@ describe('Liquality wallet SWIPE feature', async () => {
     expect(receiveAmountInDollar.trim()).not.contain('$00.00')
     expect(receiveAmountInDollar.trim()).not.contain('NaN')
 
-    const receiveNetworkFeeValue = await swapPage.GetSwapReceiveNetworkValue(page)
-    expect(receiveNetworkFeeValue.trim()).contain(asset1)
-
     const receiveNetworkFeeInDollar = await swapPage.GetSwapReceiveAccountFeeInDollar(page)
     expect(receiveNetworkFeeInDollar.trim()).not.contain('$0.00')
     expect(receiveNetworkFeeInDollar.trim()).not.contain('NaN')
 
-    const receiveAccountFeesValue = await swapPage.GetSwapReceiveNetworkValue(page)
-    expect(receiveAccountFeesValue.trim()).contain(asset1)
+    const receiveAccountFeesValue = await swapPage.GetSwapReceiveAccountFeeValue(page)
+    expect(receiveAccountFeesValue.trim()).contain(asset2)
 
-    const receiveAccountFeesInDollar = await swapPage.GetSwapReceiveNetworkInDollar(page)
-    expect(receiveAccountFeesInDollar.trim()).not.contain('$00.00')
-    expect(receiveAccountFeesInDollar.trim()).not.contain('NaN')
     // RATE
     await page.waitForSelector('#swap_review_rate_block')
 


### PR DESCRIPTION
## What?

For swaps where the destination (receive) side does not require a fee to be paid, it should not be displayed to the user

#Notion/ Trello
https://www.notion.so/ERC20-Providers-Broken-8529a717fbeb4b90b32514a8066e0f69

## Why?

## How?

## Testing?
- [ ] Run tests locally

## Screenshots (optional)
0

## Anything Else?
