### PR TITLE
fix: Remove slippage from SWAP screen for fastBTC

### DIFF
--- a/src/swaps/fastbtc/SwapDetails.vue
+++ b/src/swaps/fastbtc/SwapDetails.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="fastbtc-swap-details uniswap-swap-details">
-    <div class="row"><div class="col">Slippage: {{ slippagePercent }}% </div></div>
     <div class="row" v-if="item.approveTxHash"><div class="col">Approval Transaction: <a :href="getExplorerLink(item.approveTxHash)" target="_blank">{{ item.approveTxHash }}</a></div></div>
     <div class="row" v-if="item.swapTxHash"><div class="col">Swap Transaction: <a :href="getExplorerLink(item.swapTxHash)" target="_blank">{{ item.swapTxHash }}</a></div></div>
   </div>


### PR DESCRIPTION
## What?

Remove Slippage for fastBTC service provider from all places


#Notion/ Trello
https://www.notion.so/fastBtC-don-t-show-slippage-on-swap-screen-13af8d7d4c20498fa8df301fac0b3f67

## Why?

## How?

## Testing?
- [ ] Run tests locally

## Screenshots (optional)
0

## Anything Else?
