### PR TITLE
fix: disable sol as default asset

### DIFF
--- a/src/build.config.js
+++ b/src/build.config.js
@@ -17,8 +17,7 @@ export default {
       'MATIC',
       'PWETH',
       'ARBETH',
-      'FISH',
-      'SOL'
+      'FISH'
     ],
     testnet: [
       'BTC',
@@ -30,8 +29,7 @@ export default {
       'SOV',
       'MATIC',
       'PWETH',
-      'ARBETH',
-      'SOL'
+      'ARBETH'
     ]
   },
   infuraApiKey: 'da99ebc8c0964bb8bb757b6f8cc40f1f',

--- a/tests/Pages/OverviewPage.js
+++ b/tests/Pages/OverviewPage.js
@@ -245,7 +245,7 @@ class OverviewPage {
    * @constructor
    */
   async ValidateTotalAssets (page, newWallet = true) {
-    const assets = newWallet ? 8 : 9
+    const assets = newWallet ? 7 : 8
     await page.waitForSelector('#total_assets', { timeout: 60000 })
     const assetsCount = await page.$eval('#total_assets', (el) => el.textContent)
     expect(assetsCount, `Total assets should be ${assets} on overview page`).contain(`${assets} Assets`)

--- a/tests/e2e/03_receive.spec.js
+++ b/tests/e2e/03_receive.spec.js
@@ -102,7 +102,7 @@ describe('Receive tokens ["mainnet","smoke"]', async () => {
       await overviewPage.CheckAssertOverviewDetails(page, 'BTC')
     })
   })
-  const tokens = ['BTC', 'ETH', 'DAI', 'BNB', 'NEAR', 'ARBETH', 'RBTC', 'SOV', 'MATIC', 'PWETH', 'ARBETH', 'SOL']
+  const tokens = ['BTC', 'ETH', 'DAI', 'BNB', 'NEAR', 'ARBETH', 'RBTC', 'SOV', 'MATIC', 'PWETH', 'ARBETH']
   describe('Import wallet, Receive tokens', async () => {
     beforeEach(async () => {
       browser = await puppeteer.launch(testUtil.getChromeOptions())


### PR DESCRIPTION
## What?
Solana is not quite ready for prod and should be disabled as default until we test mainnet

## Tests:

When creating a new wallet:
- Solana coin should not display on the assets page
- Both testnet and mainnet
- It can still be accessed in "manage assets"