### PR TITLE
fix: btc send fee had error while calculating

### DIFF
--- a/src/views/Send/Send.vue
+++ b/src/views/Send/Send.vue
@@ -401,7 +401,9 @@ export default {
           sendFees[speed] = getSendFee(this.assetChain, feePrice)
         }
         if (this.asset === 'BTC') {
-          const client = this.client(this.activeNetwork, this.activeWalletId, this.asset)
+          const client = this.client({
+            network: this.activeNetwork, walletId: this.activeWalletId, asset: this.asset, accountId: this.account.id
+          })
           const feePerBytes = Object.values(this.assetFees).map(fee => fee.fee)
           const value = getMax ? undefined : currencyToUnit(cryptoassets[this.asset], BN(amount))
           try {


### PR DESCRIPTION
## What?

![image](https://user-images.githubusercontent.com/11529637/133417869-8f0d3c0f-1eec-4791-9bf6-bc5d01ab4797.png)

BTC send fee was not being displayed. There was an error in the code

#Notion/ Trello

https://www.notion.so/Fee-missing-4e3caa2a6e01470ea4d6e1a214bb8d5b
## Why?

## How?

## Testing?
- [ ] Run tests locally

## Screenshots (optional)


## Anything Else?
