### PR TITLE
fix: pass through accountId to permission requests

### DIFF
--- a/src/broker/Background.js
+++ b/src/broker/Background.js
@@ -163,6 +163,13 @@ class Background {
     const allowed = Object.keys(externalConnections[activeWalletId] || {}).includes(origin) &&
                     Object.keys(externalConnections[activeWalletId]?.[origin] || {}).includes(chain)
 
+    // Add `accountId` into the request if allowed
+    if (allowed) {
+      const accountList = { ...externalConnections }[activeWalletId]?.[origin]?.[chain] || []
+      const [accountId] = accountList
+      data = { ...data, accountId }
+    }
+
     switch (type) {
       case 'ENABLE_REQUEST':
         if (allowed) {

--- a/src/store/actions/executeRequest.js
+++ b/src/store/actions/executeRequest.js
@@ -1,13 +1,7 @@
-import { assets } from '@liquality/cryptoassets'
-
 export const executeRequest = async ({ getters, dispatch, state, rootState }, { request }) => {
   // Send transactions through wallet managed action
-  const { network, walletId, asset, origin } = request
+  const { network, walletId, asset, accountId } = request
   const { accountItem } = getters
-  const { externalConnections, activeWalletId } = state
-  const chain = assets[asset].chain
-  const accountList = { ...externalConnections }[activeWalletId]?.[origin]?.[chain] || []
-  const [accountId] = accountList
   const account = accountItem(accountId)
   let call
   const result = await new Promise((resolve, reject) => {
@@ -16,12 +10,12 @@ export const executeRequest = async ({ getters, dispatch, state, rootState }, { 
         network,
         walletId,
         asset,
+        accountId,
         to: request.args[0].to,
         amount: request.args[0].value,
         data: request.args[0].data,
         fee: request.args[0].fee,
-        gas: request.args[0].gas,
-        accountId
+        gas: request.args[0].gas
       })
     } else {
     // Otherwise build client

--- a/src/store/actions/requestPermission.js
+++ b/src/store/actions/requestPermission.js
@@ -34,7 +34,7 @@ export const requestPermission = async ({ state, dispatch, commit }, { origin, d
     if (!state.unlockedAt) throw new Error('Wallet is locked. Unlock the wallet first.')
     if (!state.activeWalletId) throw new Error('No active wallet found. Create a wallet first.')
 
-    let { asset, method, args } = data
+    let { asset, accountId, method, args } = data
 
     if (!ALLOWED.some(re => re.test(method))) throw new Error('Method not allowed')
 
@@ -54,6 +54,7 @@ export const requestPermission = async ({ state, dispatch, commit }, { origin, d
     const request = {
       origin,
       asset,
+      accountId,
       network,
       walletId,
       method,

--- a/src/views/Details/TransactionDetails.vue
+++ b/src/views/Details/TransactionDetails.vue
@@ -224,11 +224,12 @@ export default {
       }
     },
     async updateTransaction () {
-      const client = this.client(
-        this.activeNetwork,
-        this.activeWalletId,
-        this.item.from
-      )
+      const client = this.client({
+        network: this.activeNetwork,
+        walletId: this.activeWalletId,
+        asset: this.item.from,
+        accountId: this.item.accountId
+      })
       const transaction =
         (await client.chain.getTransactionByHash(this.item.txHash)) ||
         this.item.tx

--- a/src/views/PermissionSignPsbt.vue
+++ b/src/views/PermissionSignPsbt.vue
@@ -85,6 +85,9 @@ export default {
     logo () {
       return LogoWallet
     },
+    accountId () {
+      return this.request.accountId
+    },
     asset () {
       return this.request.asset
     },
@@ -123,7 +126,9 @@ export default {
     }
   },
   async created () {
-    const client = this.client(this.activeNetwork, this.activeWalletId, this.asset)
+    const client = this.client({
+      network: this.activeNetwork, walletId: this.activeWalletId, asset: this.asset, accountId: this.accountId
+    })
 
     const maxAddresses = 500
     const addressesPerCall = 50


### PR DESCRIPTION
## What?

Instead of retrieving the currently connected account when the request is being executed,
send the accountId through the permission request. This ensures the request is locked to the correct account when it is accepted and also allows us to display account information in the permission requests in the future

## Testing?
Test injection with dapps (regression)
I tested sovryn continues to work and connect to correct account

