### PR TITLE
"ethereum based network" -> Web3 network

### DIFF
--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -14,7 +14,7 @@
       </div>
       <div class="setting-item">
         <div class="setting-item_title flex-fill" id="settings_item_web_network">Web3 Network
-          <span class="setting-item_sub">Select which ethereum based network should be used for dapps.</span>
+          <span class="setting-item_sub">Select which Web3 network should be used for dapps.</span>
         </div>
         <div class="setting-item_control">
           <ChainDropdown :chains="ethereumChains"

--- a/tests/e2e/09_menu_options.spec.js
+++ b/tests/e2e/09_menu_options.spec.js
@@ -61,7 +61,7 @@ describe('Hamburger menu options', async () => {
 
     // Web3 Network dropdown
     const settingsItemWebNetwork = await page.$eval('#settings_item_web_network', (el) => el.textContent)
-    expect(settingsItemWebNetwork).contains('Select which ethereum based network should be used for dapps.')
+    expect(settingsItemWebNetwork).contains('Select which Web3 network should be used for dapps.')
 
     // Check the Analytics toggle option has been added
     await page.waitForSelector('#analytics_toggle_button', { visible: true })


### PR DESCRIPTION
I would not say RSK is "ethereum based" but that it is an EVM bitcoin sidechain with Web3 compatible dapps. I think changing this phrase from calling it "ethereum based network" to "Web3 network" is more in line with what this setting is for.