### PR TITLE
test: linear.app integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ git tag <TAG NAME>
 git push origin <TAG NAME>
 ```
 
+### Linear.app integration
+branch name format: username/liq-xx-title
+eg: b0b/liq-21-integrate-github-with-linear
 
 
 ## License


### PR DESCRIPTION
## What?

testing integration to linear.app
https://linear.app/liquality/issue/LIQ-21/integrate-github-with-linear

## How?

the branch name `b0b/liq-21-integrate-github-with-linear` is supposed to be detected by linear.app

<img width="388" alt="Screen Shot 2021-10-06 at 6 26 46 AM" src="https://user-images.githubusercontent.com/91906195/136211722-5809d50c-ac58-47ba-905b-5e2bcad89459.png">


## Anything Else?
nope