### PR TITLE
fix: Redirect to overview page when user is changing the networks from Account page

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,7 +44,7 @@ export default {
       if (unlocked) this.$router.replace('/wallet')
     },
     activeNetwork: function (_network) {
-      if (['Send', 'Receive', 'Swap'].includes(this.$route.name)) {
+      if (['Send', 'Receive', 'Swap', 'Account'].includes(this.$route.name)) {
         this.$router.replace('/wallet')
       }
     }


### PR DESCRIPTION
Redirect to overview page when user is changing the networks from the Account page, make it consistent with Send/Receive/Swap pages