### PR TITLE
fix: Arbitrum explorer incorrect address

### DIFF
--- a/src/utils/asset.js
+++ b/src/utils/asset.js
@@ -81,11 +81,11 @@ const EXPLORERS = {
   arbitrum: {
     testnet: {
       tx: 'https://rinkeby-explorer.arbitrum.io/tx/0x{hash}',
-      address: 'https://rinkeby-explorer.arbitrum.io/address/0x{hash}'
+      address: 'https://rinkeby-explorer.arbitrum.io/address/{hash}'
     },
     mainnet: {
-      tx: 'https://explorer.arbitrum.io/tx/0x',
-      address: 'https://explorer.arbitrum.io/address/0x'
+      tx: 'https://explorer.arbitrum.io/tx/0x{hash}',
+      address: 'https://explorer.arbitrum.io/address/{hash}'
     }
   }
 }


### PR DESCRIPTION
#Linear Ticket
[Linear Issue](https://linear.app/liquality/issue/LIQ-419/view-in-explorer-fails-for-arbitrum)

## Why?
Incorrect URL for Arbitrum explorer.

## How?
Provide correct URL and address without 0x prefix.

## Testing?
- [x] Run tests locally

## Screenshots (optional)

## Anything Else?
