### PR TITLE
fix: If one of the request for getting balance failed all of the concurrent requests were not executed

### DIFF
--- a/src/store/actions/updateBalances.js
+++ b/src/store/actions/updateBalances.js
@@ -42,7 +42,7 @@ export const updateBalances = async ({ state, commit, getters }, { network, wall
 
         commit('UPDATE_BALANCE', { network, accountId: account.id, walletId, asset, balance }) 
       } catch (err) {
-        console.log(err)
+        console.error(err)
        }
 
       // Commit to the state the addresses


### PR DESCRIPTION
 If one of the request for getting balance failed all of the concurrent requests were not executed thats why i added try catch around the request so if one of them fails not to block other rpc calls

Before:

![image](https://user-images.githubusercontent.com/32274987/138653849-3caa3eb7-c169-4d8f-831e-397dc43e2fde.png)


After:

![image](https://user-images.githubusercontent.com/32274987/138653929-d22268cf-0b23-4698-b3b9-ef0abe633604.png)
