### PR TITLE
fix: custom fees visuals

### DIFF
--- a/src/components/CustomFees.vue
+++ b/src/components/CustomFees.vue
@@ -197,7 +197,7 @@ export default {
       } else {
         const chainId = cryptoassets[this.asset].chain
         const { unit } = chains[chainId].fees
-        return `${this.fee} ${unit}`
+        return `${this.fee || 0} ${unit}`
       }
     },
     getFiatAmount (name) {

--- a/src/views/Send/Send.vue
+++ b/src/views/Send/Send.vue
@@ -59,7 +59,7 @@
                   <div class="send_fees">
                     <span class="selectors-asset">{{ assetChain }}</span>
                     <div class="custom-fees" v-if="customFee">
-                    {{ currentFee }} {{ assetChain }} / {{ totalFeeInFiat }} USD
+                    {{ prettyFee }} {{ assetChain }} / {{ totalFeeInFiat }} USD
                     <button class="btn btn-link" @click="resetCustomFee">
                       Reset
                     </button>


### PR DESCRIPTION
#Linear Ticket
LIQ-121
[Linear Issue](https://linear.app/liquality/issue/LIQ-121/in-case-of-rsk-send-user-set-custom-fees-it-displays-in-scientific)

## Why?
Incorrect display (scientific notation) of custom fee.

## How?
Using `prettyFee` instead of `customFee`

## Testing?
- [x] Run tests locally

## Screenshots (optional)
0

## Anything Else?
This issue is also fixed as part of the PR (NaN value when custom fee field is empty is now changed to 0).
![Screenshot 2021-10-25 at 17 03 11](https://user-images.githubusercontent.com/6750139/138715788-05dfce07-871f-4b3a-b610-994f30c8a75c.png)


