### PR TITLE
fix: store custom token decimals in number format instead of a string

### DIFF
--- a/src/store/actions/addCustomToken.js
+++ b/src/store/actions/addCustomToken.js
@@ -1,4 +1,4 @@
 export const addCustomToken = async ({ commit }, { network, walletId, chain, symbol, name, contractAddress, decimals }) => {
-  const customToken = { symbol, name, contractAddress, decimals, chain: chain }
+  const customToken = { symbol, name, contractAddress, decimals: Number(decimals), chain: chain }
   commit('ADD_CUSTOM_TOKEN', { network, walletId, customToken })
 }


### PR DESCRIPTION
# :books: Linear Ticket :books:

[LIQ-861](https://linear.app/liquality/issue/LIQ-861/custom-tokens-decimals-are-stored-as-string-instead-of-number)
