### PR TITLE
fix: custom token improvements

### DIFF
--- a/src/store/utils.js
+++ b/src/store/utils.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 import { random, findKey, mapKeys, mapValues } from 'lodash-es'
 import axios from 'axios'
-import { assets as cryptoassets } from '@liquality/cryptoassets'
+import cryptoassets from '@/utils/cryptoassets'
 import { Client } from '@liquality/client'
 import { EthereumRpcProvider } from '@liquality/ethereum-rpc-provider'
 import { EthereumJsWalletProvider } from '@liquality/ethereum-js-wallet-provider'

--- a/src/swaps/uniswap/UniswapSwapProvider.js
+++ b/src/swaps/uniswap/UniswapSwapProvider.js
@@ -112,6 +112,8 @@ class UniswapSwapProvider extends SwapProvider {
     if (allowance.gte(inputAmount)) {
       return false
     }
+
+    return true
   }
 
   async buildApprovalTx ({ network, walletId, quote }) {

--- a/src/views/CustomToken.vue
+++ b/src/views/CustomToken.vue
@@ -168,7 +168,7 @@ export default {
           contractAddress: this.contractAddress,
           name: this.name,
           symbol: this.symbol,
-          decimals: this.decimals
+          decimals: Number(this.decimals)
         })
       }
       await this.enableAssets({


### PR DESCRIPTION
# :books: Linear Ticket :books:

[LIQ-861](https://linear.app/liquality/issue/LIQ-861/custom-tokens-decimals-are-stored-as-string-instead-of-number)