### PR TITLE
feat: cryptoassets 1.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@liquality/bitcoin-swap-provider": "1.11.2",
         "@liquality/client": "1.11.2",
         "@liquality/crypto": "1.11.2",
-        "@liquality/cryptoassets": "^1.7.1",
+        "@liquality/cryptoassets": "^1.7.2",
         "@liquality/ethereum-erc20-provider": "1.11.2",
         "@liquality/ethereum-erc20-scraper-swap-find-provider": "1.11.2",
         "@liquality/ethereum-erc20-swap-provider": "1.11.2",
@@ -4599,9 +4599,9 @@
       }
     },
     "node_modules/@liquality/cryptoassets": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@liquality/cryptoassets/-/cryptoassets-1.7.1.tgz",
-      "integrity": "sha512-My1I4ccSLy1J2j76NgqpaDm7G5MOIFYdv7zQpM1+vHpnpkeFpUup0y2eTqcKnOYL+Mhhoxph3HsS+WirW3Chfg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@liquality/cryptoassets/-/cryptoassets-1.7.2.tgz",
+      "integrity": "sha512-/3MrPjM/wn3Gz9877WJbb3bDMFKkYwW3w2gccumWi1YKuQTypjXw8BYmXgMzmwYo2uz0ysrbIBs+547uG127fA==",
       "dependencies": {
         "bignumber.js": "^8.0.1",
         "bitcoin-address-validation": "^0.2.9",
@@ -4953,6 +4953,27 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.0.tgz",
       "integrity": "sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw=="
+    },
+    "node_modules/@liquality/hw-web-bridge/node_modules/@liquality/cryptoassets": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@liquality/cryptoassets/-/cryptoassets-1.7.1.tgz",
+      "integrity": "sha512-My1I4ccSLy1J2j76NgqpaDm7G5MOIFYdv7zQpM1+vHpnpkeFpUup0y2eTqcKnOYL+Mhhoxph3HsS+WirW3Chfg==",
+      "dependencies": {
+        "bignumber.js": "^8.0.1",
+        "bitcoin-address-validation": "^0.2.9",
+        "bs58": "^4.0.1",
+        "cashaddrjs": "^0.4.4",
+        "ethereumjs-util": "^7.1.3",
+        "lodash": "^4.17.11"
+      }
+    },
+    "node_modules/@liquality/hw-web-bridge/node_modules/@liquality/cryptoassets/node_modules/bignumber.js": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+      "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/@liquality/hw-web-bridge/node_modules/axios": {
       "version": "0.24.0",
@@ -42412,9 +42433,9 @@
       }
     },
     "@liquality/cryptoassets": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@liquality/cryptoassets/-/cryptoassets-1.7.1.tgz",
-      "integrity": "sha512-My1I4ccSLy1J2j76NgqpaDm7G5MOIFYdv7zQpM1+vHpnpkeFpUup0y2eTqcKnOYL+Mhhoxph3HsS+WirW3Chfg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@liquality/cryptoassets/-/cryptoassets-1.7.2.tgz",
+      "integrity": "sha512-/3MrPjM/wn3Gz9877WJbb3bDMFKkYwW3w2gccumWi1YKuQTypjXw8BYmXgMzmwYo2uz0ysrbIBs+547uG127fA==",
       "requires": {
         "bignumber.js": "^8.0.1",
         "bitcoin-address-validation": "^0.2.9",
@@ -42764,6 +42785,26 @@
           "version": "6.10.0",
           "resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-6.10.0.tgz",
           "integrity": "sha512-lLseUPEhSFUXYTKj6q7s2O3s2vW2ebgA11vMAlKodXGf5AFw4zUoEbTz9CoFOC9jS6xY4Qr8BmRnxP/odT4Uuw=="
+        },
+        "@liquality/cryptoassets": {
+          "version": "1.7.1",
+          "resolved": "https://registry.npmjs.org/@liquality/cryptoassets/-/cryptoassets-1.7.1.tgz",
+          "integrity": "sha512-My1I4ccSLy1J2j76NgqpaDm7G5MOIFYdv7zQpM1+vHpnpkeFpUup0y2eTqcKnOYL+Mhhoxph3HsS+WirW3Chfg==",
+          "requires": {
+            "bignumber.js": "^8.0.1",
+            "bitcoin-address-validation": "^0.2.9",
+            "bs58": "^4.0.1",
+            "cashaddrjs": "^0.4.4",
+            "ethereumjs-util": "^7.1.3",
+            "lodash": "^4.17.11"
+          },
+          "dependencies": {
+            "bignumber.js": {
+              "version": "8.1.1",
+              "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
+              "integrity": "sha512-QD46ppGintwPGuL1KqmwhR0O+N2cZUg8JG/VzwI2e28sM9TqHjQB10lI4QAaMHVbLzwVLLAwEglpKPViWX+5NQ=="
+            }
+          }
         },
         "axios": {
           "version": "0.24.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@liquality/bitcoin-swap-provider": "1.11.2",
     "@liquality/client": "1.11.2",
     "@liquality/crypto": "1.11.2",
-    "@liquality/cryptoassets": "^1.7.1",
+    "@liquality/cryptoassets": "^1.7.2",
     "@liquality/ethereum-erc20-provider": "1.11.2",
     "@liquality/ethereum-erc20-scraper-swap-find-provider": "1.11.2",
     "@liquality/ethereum-erc20-swap-provider": "1.11.2",


### PR DESCRIPTION
# :books: Linear Ticket :books:
Update cryptoassets verions from 1.7.1 to 1.7.2.
Important: @liquality/hw-web-bridge is still using cryptoassets 1.7.1 !
