### PR TITLE
feat: LIQ-1049, swap history send provider

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -98,6 +98,7 @@ store.subscribe(async ({ type, payload }, state) => {
         properties: {
           category: 'Send/Receive',
           action: 'Funds sent',
+          fiatRate: payload.transaction.fiatRate,
           fromAsset: cryptoassets[payload.transaction.from],
           toAsset: cryptoassets[payload.transaction.to],
           fee: `${payload.feeLabel}`
@@ -159,12 +160,13 @@ store.subscribe(async ({ type, payload }, state) => {
       // eslint-disable-next-line
       const item = getters.historyItemById(payload.network, payload.walletId, payload.id);
       if (item.type === 'SWAP' && payload.updates) {
-        if (payload.updates.status !== undefined) {
+        if (!payload.updates.status) {
           dispatch('trackAnalytics', {
             event: 'Swap status change',
             properties: {
               category: 'Swaps',
               action: 'Swap Status changed',
+              swapProvider: `${item.provider}`,
               label: `${item.from} to ${item.to}`,
               swapStatus: `${payload.updates.status}`
             }
@@ -172,15 +174,17 @@ store.subscribe(async ({ type, payload }, state) => {
         }
       }
       if (item.type === 'SEND' && payload.updates) {
-        dispatch('trackAnalytics', {
-          event: 'Send status change',
-          properties: {
-            category: 'Send/Receive',
-            action: 'Send Status changed',
-            asset: `${item.from}`,
-            sendStatus: `${payload.updates.status}`
-          }
-        })
+        if (!payload.updates.status) {
+          dispatch('trackAnalytics', {
+            event: 'Send status change',
+            properties: {
+              category: 'Send/Receive',
+              action: 'Send Status changed',
+              asset: `${item.from}`,
+              sendStatus: `${payload.updates.status}`
+            }
+          })
+        }
       }
       break
     case 'SETUP_WALLET':


### PR DESCRIPTION
# :books: Linear Ticket :books:

[LIQ-1049](https://linear.app/liquality/issue/LIQ-1049/[amplitude]-send-serviceprovider-in-swap-transaction-status)