### PR TITLE
fix: remove duplicate providers on info modal

### DIFF
--- a/src/views/Swap/SwapProvidersInfoModal.vue
+++ b/src/views/Swap/SwapProvidersInfoModal.vue
@@ -11,7 +11,7 @@
         </p>
         <div class="swap-providers-info_links mb-4 border-bottom">
           <ul>
-            <li v-for="provider in providers" :key="provider.id" class="py-1 px-2">
+            <li v-for="provider in uniqueProvides" :key="provider.id" class="py-1 px-2">
               <span class="d-flex align-items-center"
                 ><img :src="getProviderIcon(provider.id)" class="mr-2" /> {{ provider.name }}</span
               >
@@ -78,6 +78,9 @@ export default {
           }
         }
       )
+    },
+    uniqueProvides() {
+      return [...new Map(this.providers.map((item) => [item['name'], item])).values()]
     }
   },
   methods: {


### PR DESCRIPTION
# :books: Linear Ticket :books:

Duplication of Boost in the SwapProvidersInfoModal