### PR TITLE
fix: correct accountId in fee funder on erc20 to native boost

### DIFF
--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -12,7 +12,10 @@
         <EthRequiredMessage :account-id="account.id" />
       </InfoNotification>
       <InfoNotification v-if="!canCoverAmmFee">
-        <BridgeAssetRequiredMessage :account-id="toAccount.id" :asset="selectedQuote.bridgeAsset" />
+        <BridgeAssetRequiredMessage
+          :account-id="getAccountId()"
+          :asset="selectedQuote.bridgeAsset"
+        />
       </InfoNotification>
 
       <InfoNotification v-else-if="showNoLiquidityMessage && sendAmount >= min && sendAmount > 0">
@@ -1211,6 +1214,15 @@ export default {
         this.updateSwapFees()
       }
     }, 800),
+    getAccountId() {
+      if (
+        this.selectedQuoteProvider.config.type === SwapProviderType.LIQUALITYBOOST_ERC20_TO_NATIVE
+      ) {
+        return this.fromAccountId
+      }
+
+      return this.toAccountId
+    },
     applyCustomFee({ asset, fee }) {
       const assetFees = this.getAssetFees(asset)
       const presetFee = Object.entries(assetFees).find(


### PR DESCRIPTION
# :books: Linear Ticket :books:

[LIQ-1271](https://linear.app/liquality/issue/LIQ-1271/get-rbtc-error-display-on-liquality-boost-swap-sov-to-avax-when-user)