### PR TITLE
fix: set sovryn min amount to 0

### DIFF
--- a/src/swaps/sovryn/SovrynSwapProvider.js
+++ b/src/swaps/sovryn/SovrynSwapProvider.js
@@ -282,6 +282,12 @@ class SovrynSwapProvider extends SwapProvider {
     return fees
   }
 
+  // ======== MIN AMOUNT =======
+
+  getSwapLimit() {
+    return 0 // Min swap amount in USD
+  }
+
   // ======== STATE TRANSITIONS ========
 
   async waitForApproveConfirmations({ swap, network, walletId }) {


### PR DESCRIPTION
# :books: Linear Ticket :books:
[LIQ-1291](https://linear.app/liquality/issue/LIQ-1291/no-quote-is-appearing-for-bpro-to-any-other-rsk-token-as-the-min-of)
