### PR TITLE
fix: Locked wallet should show password screen

### DIFF
--- a/src/views/Splash.vue
+++ b/src/views/Splash.vue
@@ -48,6 +48,8 @@ export default {
   async created() {
     if (this.unlockedAt) {
       this.$router.replace('/wallet')
+    } else if (this.keyUpdatedAt) {
+      this.$router.replace('/open')
     }
   }
 }


### PR DESCRIPTION
# :books: Linear Ticket :books:

Expected: Starting screen should be password if wallet is locked
Actual: Starting screen was the splash screen with "Open wallet" button