### PR TITLE
feat: prevent zero error for non dollar value assets

### DIFF
--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -479,6 +479,7 @@ export default {
       showSwapProvidersInfoModal: false,
       quotes: [],
       updatingQuotes: false,
+      firstUpdate: false,
       selectedQuote: null,
       userSelectedQuote: false,
       swapFees: {},
@@ -783,7 +784,11 @@ export default {
         return 'Please reduce amount. It exceeds maximum.'
       }
 
-      if (amount.lt(this.min) || amount.lte(0)) {
+      // when amount is equal to 0 and asset has no dollar value, prevent error from appearing until first update
+      const zeroCheck =
+        !this.fiatRates[this.asset] && !this.firstUpdate ? amount.lt(0) : amount.lte(0)
+
+      if (amount.lt(this.min) || zeroCheck) {
         return 'Please increase amount. It is below minimum.'
       }
 
@@ -1103,6 +1108,7 @@ export default {
         }
       }
       this.updatingQuotes = false
+      this.firstUpdate = true
       this.resetQuoteTimer()
     }, 1000),
     updateQuotes() {


### PR DESCRIPTION
# :books: Linear Ticket :books:

[LIQ-1291](https://linear.app/liquality/issue/LIQ-1291#comment-68afa2e4)
Hides error 'Please increase amount. It is below minimum.' before first update of swipe providers for assets that have np dollar value (in most cases Rootstock ERC20s).