### PR TITLE
feat: show error when bridge asset of boost is disabled

### DIFF
--- a/src/components/BoostActivateBridgeAsset.vue
+++ b/src/components/BoostActivateBridgeAsset.vue
@@ -25,7 +25,6 @@ export default {
         walletId: this.walletId,
         assets: [this.asset]
       }
-      console.log(this.network, this.walletId, this.asset)
       this.enableAssets(params)
     }
   }

--- a/src/components/BoostActivateBridgeAsset.vue
+++ b/src/components/BoostActivateBridgeAsset.vue
@@ -1,0 +1,49 @@
+<template>
+  <div class="notification-content">
+    <div class="notification-text">
+      Required Native Asset ({{ asset }}) for Boost swap is disabled.
+    </div>
+    <button type="button" class="btn btn-option get-bridgeAsset-btn" @click="toggleAsset()">
+      Enable
+    </button>
+  </div>
+</template>
+
+<script>
+import { mapActions } from 'vuex'
+
+export default {
+  props: ['network', 'walletId', 'asset'],
+  created() {
+    console.log(this.network, this.walletId, this.asset)
+  },
+  methods: {
+    ...mapActions(['enableAssets']),
+    toggleAsset() {
+      const params = {
+        network: this.network,
+        walletId: this.walletId,
+        assets: [this.asset]
+      }
+      console.log(this.network, this.walletId, this.asset)
+      this.enableAssets(params)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.notification-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .get-bridgeAsset-btn {
+    width: 90px;
+    display: inline-block;
+  }
+  .notification-text {
+    width: 230px;
+  }
+}
+</style>

--- a/src/components/BoostActivateBridgeAsset.vue
+++ b/src/components/BoostActivateBridgeAsset.vue
@@ -1,10 +1,8 @@
 <template>
   <div class="notification-content">
-    <div class="notification-text">
-      Required Native Asset ({{ asset }}) for Boost swap is disabled.
-    </div>
+    <div class="notification-text">To trade this pair {{ asset }} has to be enabled</div>
     <button type="button" class="btn btn-option get-bridgeAsset-btn" @click="toggleAsset()">
-      Enable
+      OK, do it
     </button>
   </div>
 </template>
@@ -14,9 +12,6 @@ import { mapActions } from 'vuex'
 
 export default {
   props: ['network', 'walletId', 'asset'],
-  created() {
-    console.log(this.network, this.walletId, this.asset)
-  },
   methods: {
     ...mapActions(['enableAssets']),
     toggleAsset() {
@@ -38,7 +33,7 @@ export default {
   align-items: center;
 
   .get-bridgeAsset-btn {
-    width: 90px;
+    width: 70px;
     display: inline-block;
   }
   .notification-text {

--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -824,6 +824,7 @@ export default {
         this.updatingQuotes ||
         this.ethRequired ||
         //!this.canCoverAmmFee ||
+        this.showBridgeAssetDisabledMessage ||
         this.showNoLiquidityMessage ||
         this.amountError ||
         BN(this.safeAmount).lte(0)

--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -761,10 +761,14 @@ export default {
 
       const account = isERC20(this.asset) ? this.account : this.toAccount
       const balance = account?.balances[this.selectedQuote.bridgeAsset]
+
+      if (!balance) return true
+
       const SwapFeeInUnits = currencyToUnit(
         cryptoassets[this.selectedQuote.bridgeAsset],
         isERC20(this.asset) ? this.fromSwapFee : this.receiveFee
       )
+
       return BN(balance).gt(SwapFeeInUnits)
     },
     availableAmount() {


### PR DESCRIPTION
# :books: Linear Ticket :books:

[LIQ-1062](https://linear.app/liquality/issue/LIQ-1062/user-need-to-increase-the-input-amount-to-see-the-liquidity-between)
Blocks boost swaps when bridge asset is disabled