### PR TITLE
feat: improve minimum amount logic for boosts

### DIFF
--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -692,9 +692,12 @@ export default {
             min = this.selectedQuote.min
             break
           case SwapProviderType.LiqualityBoostERC20ToNative:
+            // increase minimum amount with 5% to minimize calculation
+            // error and price fluctuation
             min = BN(this.selectedQuote.minInBridgeAsset)
               .times(this.fiatRates[this.selectedQuote.bridgeAsset])
               .dividedBy(this.fiatRates[this.asset])
+              .times(1.05)
             break
           default:
             min = BN.min(fiatToCrypto(MIN_SWAP_VALUE_USD, this.fiatRates[this.asset]))

--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -692,12 +692,9 @@ export default {
             min = this.selectedQuote.min
             break
           case SwapProviderType.LiqualityBoostERC20ToNative:
-            // increase minimum amount with 5% to minimize calculation
-            // error and price fluctuation
             min = BN(this.selectedQuote.minInBridgeAsset)
               .times(this.fiatRates[this.selectedQuote.bridgeAsset])
               .dividedBy(this.fiatRates[this.asset])
-              .times(1.05)
             break
           default:
             min = BN.min(fiatToCrypto(MIN_SWAP_VALUE_USD, this.fiatRates[this.asset]))

--- a/src/views/Swap/Swap.vue
+++ b/src/views/Swap/Swap.vue
@@ -438,7 +438,6 @@ import LedgerSignRequestModal from '@/components/LedgerSignRequestModal'
 import OperationErrorModal from '@/components/OperationErrorModal'
 import CustomFees from '@/components/CustomFees'
 import CustomFeesEIP1559 from '@/components/CustomFeesEIP1559'
-import { getSwapProviderConfig } from '@liquality/wallet-core/dist/swaps/utils'
 import { calculateQuoteRate, sortQuotes } from '@liquality/wallet-core/dist/utils/quotes'
 import { version as walletVersion } from '../../../package.json'
 import LedgerBridgeModal from '@/components/LedgerBridgeModal'
@@ -503,7 +502,8 @@ export default {
       swapErrorMessage: '',
       customFeeAssetSelected: null,
       customFees: {},
-      bridgeModalOpen: false
+      bridgeModalOpen: false,
+      updateInitialDefaultValue: false
     }
   },
   props: {
@@ -678,36 +678,27 @@ export default {
     min() {
       if (!this.fiatRates[this.asset]) return BN(0)
 
-      const toQuoteAsset =
-        this.selectedQuoteProvider?.config?.type === SwapProviderType.LiqualityBoostNativeToERC20
-          ? this.toAssetChain
-          : this.toAsset
-
-      const fromQuoteAsset =
-        this.selectedQuoteProvider?.config?.type === SwapProviderType.LiqualityBoostERC20ToNative
-          ? this.assetChain
-          : this.asset
-
-      const liqualityMarket = this.networkMarketData?.find((pair) => {
-        return (
-          pair.from === fromQuoteAsset &&
-          pair.to === toQuoteAsset &&
-          getSwapProviderConfig(this.activeNetwork, pair.provider).type ===
-            SwapProviderType.Liquality
-        )
-      })
-
       const getSwapLimit = this.selectedQuoteProvider?.getSwapLimit
-
       let min
-
       if (getSwapLimit) {
         const minUsdValue = getSwapLimit()
         min = BN.min(fiatToCrypto(minUsdValue, this.fiatRates[this.asset]))
       } else {
-        min = liqualityMarket
-          ? BN(liqualityMarket.min)
-          : BN.min(fiatToCrypto(MIN_SWAP_VALUE_USD, this.fiatRates[this.asset]))
+        const swapProvider = this.selectedQuoteProvider?.config?.type
+
+        switch (swapProvider) {
+          case SwapProviderType.Liquality:
+          case SwapProviderType.LiqualityBoostNativeToERC20:
+            min = this.selectedQuote.min
+            break
+          case SwapProviderType.LiqualityBoostERC20ToNative:
+            min = BN(this.selectedQuote.minInBridgeAsset)
+              .times(this.fiatRates[this.selectedQuote.bridgeAsset])
+              .dividedBy(this.fiatRates[this.asset])
+            break
+          default:
+            min = BN.min(fiatToCrypto(MIN_SWAP_VALUE_USD, this.fiatRates[this.asset]))
+        }
       }
 
       return isNaN(min) ? BN(0) : dpUI(min)
@@ -1114,9 +1105,11 @@ export default {
           } else {
             this.userSelectedQuote = false
             this.selectedQuote = this.bestQuote
+            this.updateInitialDefaultValue = false
           }
         } else {
           this.selectedQuote = this.bestQuote
+          this.updateInitialDefaultValue = false
         }
       }
       this.updatingQuotes = false
@@ -1334,6 +1327,16 @@ export default {
 
       if (this.amountOption === 'max') {
         this.sendAmount = dpUI(this.max)
+      }
+    },
+    min: function (val, oldVal) {
+      // minimum set correctly
+      if (this.updateInitialDefaultValue) return
+
+      // update to new minimum when provider is changed
+      if (!BN(val).eq(oldVal)) {
+        this.sendAmount = dpUI(val)
+        this.updateInitialDefaultValue = true
       }
     },
     selectedQuote: function () {


### PR DESCRIPTION
# :books: Linear Ticket :books:
[LIQ-1393](https://linear.app/liquality/issue/LIQ-1393/liquality-boost-or-reduce-the-min-for-pweth-to-btc-so-that-user-can)
[LIQ-1062](https://linear.app/liquality/issue/LIQ-1062/user-need-to-increase-the-input-amount-to-see-the-liquidity-between)
