### PR TITLE
fix: get rid of duplicate balance update dispatching

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -77,10 +77,6 @@ store.subscribe(async ({ type, payload }, state) => {
         network: state.activeNetwork,
         walletId: state.activeWalletId
       })
-      dispatch('updateBalances', {
-        network: state.activeNetwork,
-        walletId: state.activeWalletId
-      })
       dispatch('updateFiatRates', { assets: store.getters.allNetworkAssets })
       dispatch('updateMarketData', { network: state.activeNetwork })
       dispatch('checkPendingActions', { walletId: state.activeWalletId })


### PR DESCRIPTION
the `updateBalances` action is dispatched twice during wallet unlock:

1. once during `Wallet.vue` component creation (in `created()`)
2. once in the `UNLOCK_WALLET` listener in `background.js`

When the wallet is unlocked the first component is always `Wallet` so we can get rid of the dispatch that happens in `UNLOCK_WALLET`
