### PR TITLE
feat: LIQ-1470 - track create wallet and Import with seed phrase

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -32,14 +32,36 @@ store.subscribe(async ({ type, payload }, state) => {
 
   switch (type) {
     case 'CREATE_WALLET':
-      await dispatch('trackAnalytics', {
-        event: 'Create a new wallet',
-        properties: {
-          walletVersion,
-          label: 'New wallet created',
-          action: 'User created a new wallet with new seed phrase'
-        }
-      })
+      // Analytics Opt in event (if state has acceptedData is not 0)
+      if (state.analytics?.acceptedDate > 0) {
+        dispatch('trackAnalytics', {
+          event: 'User Opt-In to Analytics',
+          properties: {
+            category: 'Analytics'
+          }
+        })
+      }
+      // Import with seed phrase event
+      if (state.wallets[0].imported) {
+        dispatch('trackAnalytics', {
+          event: 'Import with seed phrase',
+          properties: {
+            walletVersion,
+            label: 'Import with seed phrase',
+            action: 'User created wallet with import seed phrase'
+          }
+        })
+      } else {
+        // Create wallet event
+        dispatch('trackAnalytics', {
+          event: 'Create a new wallet',
+          properties: {
+            walletVersion,
+            label: 'New wallet created',
+            action: 'User created a new wallet with new seed phrase'
+          }
+        })
+      }
       break
 
     case 'CHANGE_ACTIVE_NETWORK':


### PR DESCRIPTION
feat: LIQ-1470 - track Opt In events separately

https://linear.app/liquality/issue/LIQ-1471/[amplitude]-track-create-wallet-vs-import-with-seed-phrase-existing

https://linear.app/liquality/issue/LIQ-1470/[amplitude]-track-just-opt-in-event-separately



# :books: Linear Ticket :books:

![image](https://user-images.githubusercontent.com/5720338/175546387-827c09cc-4382-4fad-a2d6-08bf84f34528.png)

