### PR TITLE
NFT Updates

### DIFF
--- a/src/views/Details/NFTCollectionList.vue
+++ b/src/views/Details/NFTCollectionList.vue
@@ -11,7 +11,7 @@
         >
       </span>
     </NavBar>
-    <div class="nft-collection mt-3">
+    <div class="nft-collection">
       <NFTAsset
         v-for="asset in nftCollection"
         :key="asset.id"
@@ -75,7 +75,7 @@ export default {
 
 <style lang="scss" scoped>
 .nft-collectibles {
-  overflow-y: auto;
+  overflow-y: hidden;
   .section-header {
     font-size: 20px;
     line-height: 25.78px;
@@ -109,11 +109,12 @@ export default {
     }
   }
   .nft-collection {
-    padding: 0 10px;
+    padding: 16px 10px;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     grid-gap: 5px;
     overflow-y: auto;
+    height: 100%;
   }
 }
 </style>

--- a/src/views/Swap/Accounts.vue
+++ b/src/views/Swap/Accounts.vue
@@ -16,7 +16,12 @@
         </div>
       </div>
       <div class="list-items">
-        <WalletAccounts @item-selected="onAccountSelected" :search="search" :accounts="accounts" />
+        <WalletAccounts
+          @item-selected="onAccountSelected"
+          :search="search"
+          :accounts="accounts"
+          :isAssetList="true"
+        />
       </div>
     </div>
   </div>


### PR DESCRIPTION
- remove NFT from the swap asset list
- make the top bar fixed on the scroll

# :books: Linear Ticket :books:

[LIQ-1556](https://linear.app/liquality/issue/LIQ-1556/title-bar-and-buttons-on-the-bottom-should-be-sticky-on-nft-screens)
[LIQ-1553](https://linear.app/liquality/issue/LIQ-1553/nft-option-should-not-display-under-select-asset-for-swap)