### PR TITLE
Labels should appear in their native language

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -88,10 +88,10 @@
     "provider": "Provider",
     "localesLabels": {
         "en": "English",
-        "es": "Spanish",
-        "zh": "Chinese (Simplified)",
-        "pt": "Portuguese",
-        "ph": "Filipino",
-        "cb": "Bisaya (Cebuano)"
+        "es": "Español",
+        "zh": "中文（简体）",
+        "pt": "Português",
+        "ph": "Tagalog",
+        "cb": "Cebuano"
     }
 }


### PR DESCRIPTION
Labels in the dropdown menu in Settings for selecting the language should appear translated in their native language.

# :books: Linear Ticket :books: https://linear.app/liquality/issue/EXT-148/ 


