### PR TITLE
fix: localize error translations

### DIFF
--- a/src/locales/cb/liquality_errors.json
+++ b/src/locales/cb/liquality_errors.json
@@ -64,5 +64,8 @@
   },
   "LedgerDeviceNotupdatedError": {
     "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  },
+  "LedgerDeviceSmartContractTransactionDisabledError": {
+    "plain": "Permission denied: enable Blind signing or Contract data in the Ethereum app Settings"
   }
 }

--- a/src/locales/cb/liquality_errors.json
+++ b/src/locales/cb/liquality_errors.json
@@ -1,0 +1,68 @@
+{
+  "InsufficientFundsError": {
+    "plain": "Kindly add more funds to cover the transaction request"
+  },
+  "InsufficientGasFeeError": {
+    "plain": "More gas is needed to cover the fees for the transaction, Kindly add more funds to cover the fees."
+  },
+  "InsufficientInputAmountError": {
+    "plain": "Due to the provider's parameters, kindly add more funds to cover the transaction request."
+  },
+  "InternalError": {
+    "plain": "There is an unknown issue, Please try again at a later time, If the problem persists, get in touch with support on discord with errorId: %{errorId}"
+  },
+  "LowSpeedupFeeError": {
+    "plain": "suggestions"
+  },
+  "PairNotSupportedError": {
+    "plain": "Due to the provider's parameters, this swap pair is not available now, Kindly select a different swap provider."
+  },
+  "ThirdPartyError": {
+    "plain": {
+      "swap": "There is an unknown issue with the provider's service, Please select a different swap provider, try again at a later time.",
+      "unknown": "Kindly try again at a later time while the provider fixes this issue"
+    }
+  },
+  "UnknownError": {
+    "plain": "There is an unknown issue, please try again at a later time, In the event the issue persists, please contact support on discord with errorId: %{errorId}"
+  },
+  "SlippageTooHighError": {
+    "plain": "Please try again (Slippage is too high)"
+  },
+  "PasswordError": {
+    "plain": "Please Try Again (Password should have 8 or more characters)"
+  },
+  "NoTipError": {
+    "plain": "Please set up the miner tip greater than 0 GWEI"
+  },
+  "VeryLowTipError": {
+    "plain": "Please use the 'Low' option. (Miner tip is extremely low)"
+  },
+  "VeryHighTipWarning": {
+    "plain": "Please use the 'High' option. (Miner tip was higher than necessary)"
+  },
+  "VeryLowMaxFeeError": {
+    "plain": "Please review the 'Max Fee' value set. (The fee must be set higher)"
+  },
+  "VeryHighMaxFeeWarning": {
+    "plain": "Please review 'Max Fee', as it is higher than necessary"
+  },
+  "DuplicateTokenSymbolError": {
+    "plain": "Token with this symbol exists"
+  },
+  "LedgerDeviceConnectionError": {
+    "plain": "Ledger device not connected,connect or reconnect your device"
+  },
+  "LedgerDappConflictError": {
+    "plain": "We weren't able to get a list of accounts. Eventually, close any other apps your Ledger is connected to, including Ledger Live, and try again."
+  },
+  "LedgerAppMismatchError": {
+    "plain": "We weren't able to get a list of accounts. Please check on the Ledger if the right app/asset was selected, or cancel and choose a different asset"
+  },
+  "LedgerDevicelockedError": {
+    "plain": "Ledger device is connected but locked, please unlock your ledger device and try again"
+  },
+  "LedgerDeviceNotupdatedError": {
+    "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  }
+}

--- a/src/locales/en/components.json
+++ b/src/locales/en/components.json
@@ -81,7 +81,7 @@
     "noLiquidityMessage": {
         "noLiquidity": "Not enough liquidity for this trade. You can request %{asset} in ",
         "tryAgainLater": " or try again later.",
-        "noTraded": "This pair isn't traded yet. Maybe there is a way to do multiple swaps to get that desired token."
+        "noTraded": "This pair isn't traded yet or there's a problem trading it at the moment. Maybe there is a way to do multiple swaps to get that desired token."
     },
     "operationErrorModal": {
         "cantFindAccount": "Can’t find the ledger Account",

--- a/src/locales/en/liquality_errors.json
+++ b/src/locales/en/liquality_errors.json
@@ -64,5 +64,8 @@
   },
   "LedgerDeviceNotupdatedError": {
     "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  },
+  "LedgerDeviceSmartContractTransactionDisabledError": {
+    "plain": "Permission denied: enable Blind signing or Contract data in the Ethereum app Settings"
   }
 }

--- a/src/locales/en/liquality_errors.json
+++ b/src/locales/en/liquality_errors.json
@@ -1,0 +1,68 @@
+{
+  "InsufficientFundsError": {
+    "plain": "Kindly add more funds to cover the transaction request"
+  },
+  "InsufficientGasFeeError": {
+    "plain": "More gas is needed to cover the fees for the transaction, Kindly add more funds to cover the fees."
+  },
+  "InsufficientInputAmountError": {
+    "plain": "Due to the provider's parameters, kindly add more funds to cover the transaction request."
+  },
+  "InternalError": {
+    "plain": "There is an unknown issue, Please try again at a later time, If the problem persists, get in touch with support on discord with errorId: %{errorId}"
+  },
+  "LowSpeedupFeeError": {
+    "plain": "suggestions"
+  },
+  "PairNotSupportedError": {
+    "plain": "Due to the provider's parameters, this swap pair is not available now, Kindly select a different swap provider."
+  },
+  "ThirdPartyError": {
+    "plain": {
+      "swap": "There is an unknown issue with the provider's service, Please select a different swap provider, try again at a later time.",
+      "unknown": "Kindly try again at a later time while the provider fixes this issue"
+    }
+  },
+  "UnknownError": {
+    "plain": "There is an unknown issue, please try again at a later time, In the event the issue persists, please contact support on discord with errorId: %{errorId}"
+  },
+  "SlippageTooHighError": {
+    "plain": "Please try again (Slippage is too high)"
+  },
+  "PasswordError": {
+    "plain": "Please Try Again (Password should have 8 or more characters)"
+  },
+  "NoTipError": {
+    "plain": "Please set up the miner tip greater than 0 GWEI"
+  },
+  "VeryLowTipError": {
+    "plain": "Please use the 'Low' option. (Miner tip is extremely low)"
+  },
+  "VeryHighTipWarning": {
+    "plain": "Please use the 'High' option. (Miner tip was higher than necessary)"
+  },
+  "VeryLowMaxFeeError": {
+    "plain": "Please review the 'Max Fee' value set. (The fee must be set higher)"
+  },
+  "VeryHighMaxFeeWarning": {
+    "plain": "Please review 'Max Fee', as it is higher than necessary"
+  },
+  "DuplicateTokenSymbolError": {
+    "plain": "Token with this symbol exists"
+  },
+  "LedgerDeviceConnectionError": {
+    "plain": "Ledger device not connected,connect or reconnect your device"
+  },
+  "LedgerDappConflictError": {
+    "plain": "We weren't able to get a list of accounts. Eventually, close any other apps your Ledger is connected to, including Ledger Live, and try again."
+  },
+  "LedgerAppMismatchError": {
+    "plain": "We weren't able to get a list of accounts. Please check on the Ledger if the right app/asset was selected, or cancel and choose a different asset"
+  },
+  "LedgerDevicelockedError": {
+    "plain": "Ledger device is connected but locked, please unlock your ledger device and try again"
+  },
+  "LedgerDeviceNotupdatedError": {
+    "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  }
+}

--- a/src/locales/es/liquality_errors.json
+++ b/src/locales/es/liquality_errors.json
@@ -64,5 +64,8 @@
   },
   "LedgerDeviceNotupdatedError": {
     "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  },
+  "LedgerDeviceSmartContractTransactionDisabledError": {
+    "plain": "Permission denied: enable Blind signing or Contract data in the Ethereum app Settings"
   }
 }

--- a/src/locales/es/liquality_errors.json
+++ b/src/locales/es/liquality_errors.json
@@ -1,0 +1,68 @@
+{
+  "InsufficientFundsError": {
+    "plain": "Kindly add more funds to cover the transaction request"
+  },
+  "InsufficientGasFeeError": {
+    "plain": "More gas is needed to cover the fees for the transaction, Kindly add more funds to cover the fees."
+  },
+  "InsufficientInputAmountError": {
+    "plain": "Due to the provider's parameters, kindly add more funds to cover the transaction request."
+  },
+  "InternalError": {
+    "plain": "There is an unknown issue, Please try again at a later time, If the problem persists, get in touch with support on discord with errorId: %{errorId}"
+  },
+  "LowSpeedupFeeError": {
+    "plain": "suggestions"
+  },
+  "PairNotSupportedError": {
+    "plain": "Due to the provider's parameters, this swap pair is not available now, Kindly select a different swap provider."
+  },
+  "ThirdPartyError": {
+    "plain": {
+      "swap": "There is an unknown issue with the provider's service, Please select a different swap provider, try again at a later time.",
+      "unknown": "Kindly try again at a later time while the provider fixes this issue"
+    }
+  },
+  "UnknownError": {
+    "plain": "There is an unknown issue, please try again at a later time, In the event the issue persists, please contact support on discord with errorId: %{errorId}"
+  },
+  "SlippageTooHighError": {
+    "plain": "Please try again (Slippage is too high)"
+  },
+  "PasswordError": {
+    "plain": "Please Try Again (Password should have 8 or more characters)"
+  },
+  "NoTipError": {
+    "plain": "Please set up the miner tip greater than 0 GWEI"
+  },
+  "VeryLowTipError": {
+    "plain": "Please use the 'Low' option. (Miner tip is extremely low)"
+  },
+  "VeryHighTipWarning": {
+    "plain": "Please use the 'High' option. (Miner tip was higher than necessary)"
+  },
+  "VeryLowMaxFeeError": {
+    "plain": "Please review the 'Max Fee' value set. (The fee must be set higher)"
+  },
+  "VeryHighMaxFeeWarning": {
+    "plain": "Please review 'Max Fee', as it is higher than necessary"
+  },
+  "DuplicateTokenSymbolError": {
+    "plain": "Token with this symbol exists"
+  },
+  "LedgerDeviceConnectionError": {
+    "plain": "Ledger device not connected,connect or reconnect your device"
+  },
+  "LedgerDappConflictError": {
+    "plain": "We weren't able to get a list of accounts. Eventually, close any other apps your Ledger is connected to, including Ledger Live, and try again."
+  },
+  "LedgerAppMismatchError": {
+    "plain": "We weren't able to get a list of accounts. Please check on the Ledger if the right app/asset was selected, or cancel and choose a different asset"
+  },
+  "LedgerDevicelockedError": {
+    "plain": "Ledger device is connected but locked, please unlock your ledger device and try again"
+  },
+  "LedgerDeviceNotupdatedError": {
+    "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  }
+}

--- a/src/locales/ph/liquality_errors.json
+++ b/src/locales/ph/liquality_errors.json
@@ -64,5 +64,8 @@
   },
   "LedgerDeviceNotupdatedError": {
     "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  },
+  "LedgerDeviceSmartContractTransactionDisabledError": {
+    "plain": "Permission denied: enable Blind signing or Contract data in the Ethereum app Settings"
   }
 }

--- a/src/locales/ph/liquality_errors.json
+++ b/src/locales/ph/liquality_errors.json
@@ -1,0 +1,68 @@
+{
+  "InsufficientFundsError": {
+    "plain": "Kindly add more funds to cover the transaction request"
+  },
+  "InsufficientGasFeeError": {
+    "plain": "More gas is needed to cover the fees for the transaction, Kindly add more funds to cover the fees."
+  },
+  "InsufficientInputAmountError": {
+    "plain": "Due to the provider's parameters, kindly add more funds to cover the transaction request."
+  },
+  "InternalError": {
+    "plain": "There is an unknown issue, Please try again at a later time, If the problem persists, get in touch with support on discord with errorId: %{errorId}"
+  },
+  "LowSpeedupFeeError": {
+    "plain": "suggestions"
+  },
+  "PairNotSupportedError": {
+    "plain": "Due to the provider's parameters, this swap pair is not available now, Kindly select a different swap provider."
+  },
+  "ThirdPartyError": {
+    "plain": {
+      "swap": "There is an unknown issue with the provider's service, Please select a different swap provider, try again at a later time.",
+      "unknown": "Kindly try again at a later time while the provider fixes this issue"
+    }
+  },
+  "UnknownError": {
+    "plain": "There is an unknown issue, please try again at a later time, In the event the issue persists, please contact support on discord with errorId: %{errorId}"
+  },
+  "SlippageTooHighError": {
+    "plain": "Please try again (Slippage is too high)"
+  },
+  "PasswordError": {
+    "plain": "Please Try Again (Password should have 8 or more characters)"
+  },
+  "NoTipError": {
+    "plain": "Please set up the miner tip greater than 0 GWEI"
+  },
+  "VeryLowTipError": {
+    "plain": "Please use the 'Low' option. (Miner tip is extremely low)"
+  },
+  "VeryHighTipWarning": {
+    "plain": "Please use the 'High' option. (Miner tip was higher than necessary)"
+  },
+  "VeryLowMaxFeeError": {
+    "plain": "Please review the 'Max Fee' value set. (The fee must be set higher)"
+  },
+  "VeryHighMaxFeeWarning": {
+    "plain": "Please review 'Max Fee', as it is higher than necessary"
+  },
+  "DuplicateTokenSymbolError": {
+    "plain": "Token with this symbol exists"
+  },
+  "LedgerDeviceConnectionError": {
+    "plain": "Ledger device not connected,connect or reconnect your device"
+  },
+  "LedgerDappConflictError": {
+    "plain": "We weren't able to get a list of accounts. Eventually, close any other apps your Ledger is connected to, including Ledger Live, and try again."
+  },
+  "LedgerAppMismatchError": {
+    "plain": "We weren't able to get a list of accounts. Please check on the Ledger if the right app/asset was selected, or cancel and choose a different asset"
+  },
+  "LedgerDevicelockedError": {
+    "plain": "Ledger device is connected but locked, please unlock your ledger device and try again"
+  },
+  "LedgerDeviceNotupdatedError": {
+    "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  }
+}

--- a/src/locales/pt/liquality_errors.json
+++ b/src/locales/pt/liquality_errors.json
@@ -64,5 +64,8 @@
   },
   "LedgerDeviceNotupdatedError": {
     "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  },
+  "LedgerDeviceSmartContractTransactionDisabledError": {
+    "plain": "Permission denied: enable Blind signing or Contract data in the Ethereum app Settings"
   }
 }

--- a/src/locales/pt/liquality_errors.json
+++ b/src/locales/pt/liquality_errors.json
@@ -1,0 +1,68 @@
+{
+  "InsufficientFundsError": {
+    "plain": "Kindly add more funds to cover the transaction request"
+  },
+  "InsufficientGasFeeError": {
+    "plain": "More gas is needed to cover the fees for the transaction, Kindly add more funds to cover the fees."
+  },
+  "InsufficientInputAmountError": {
+    "plain": "Due to the provider's parameters, kindly add more funds to cover the transaction request."
+  },
+  "InternalError": {
+    "plain": "There is an unknown issue, Please try again at a later time, If the problem persists, get in touch with support on discord with errorId: %{errorId}"
+  },
+  "LowSpeedupFeeError": {
+    "plain": "suggestions"
+  },
+  "PairNotSupportedError": {
+    "plain": "Due to the provider's parameters, this swap pair is not available now, Kindly select a different swap provider."
+  },
+  "ThirdPartyError": {
+    "plain": {
+      "swap": "There is an unknown issue with the provider's service, Please select a different swap provider, try again at a later time.",
+      "unknown": "Kindly try again at a later time while the provider fixes this issue"
+    }
+  },
+  "UnknownError": {
+    "plain": "There is an unknown issue, please try again at a later time, In the event the issue persists, please contact support on discord with errorId: %{errorId}"
+  },
+  "SlippageTooHighError": {
+    "plain": "Please try again (Slippage is too high)"
+  },
+  "PasswordError": {
+    "plain": "Please Try Again (Password should have 8 or more characters)"
+  },
+  "NoTipError": {
+    "plain": "Please set up the miner tip greater than 0 GWEI"
+  },
+  "VeryLowTipError": {
+    "plain": "Please use the 'Low' option. (Miner tip is extremely low)"
+  },
+  "VeryHighTipWarning": {
+    "plain": "Please use the 'High' option. (Miner tip was higher than necessary)"
+  },
+  "VeryLowMaxFeeError": {
+    "plain": "Please review the 'Max Fee' value set. (The fee must be set higher)"
+  },
+  "VeryHighMaxFeeWarning": {
+    "plain": "Please review 'Max Fee', as it is higher than necessary"
+  },
+  "DuplicateTokenSymbolError": {
+    "plain": "Token with this symbol exists"
+  },
+  "LedgerDeviceConnectionError": {
+    "plain": "Ledger device not connected,connect or reconnect your device"
+  },
+  "LedgerDappConflictError": {
+    "plain": "We weren't able to get a list of accounts. Eventually, close any other apps your Ledger is connected to, including Ledger Live, and try again."
+  },
+  "LedgerAppMismatchError": {
+    "plain": "We weren't able to get a list of accounts. Please check on the Ledger if the right app/asset was selected, or cancel and choose a different asset"
+  },
+  "LedgerDevicelockedError": {
+    "plain": "Ledger device is connected but locked, please unlock your ledger device and try again"
+  },
+  "LedgerDeviceNotupdatedError": {
+    "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  }
+}

--- a/src/locales/zh/liquality_errors.json
+++ b/src/locales/zh/liquality_errors.json
@@ -64,5 +64,8 @@
   },
   "LedgerDeviceNotupdatedError": {
     "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  },
+  "LedgerDeviceSmartContractTransactionDisabledError": {
+    "plain": "Permission denied: enable Blind signing or Contract data in the Ethereum app Settings"
   }
 }

--- a/src/locales/zh/liquality_errors.json
+++ b/src/locales/zh/liquality_errors.json
@@ -1,0 +1,68 @@
+{
+  "InsufficientFundsError": {
+    "plain": "Kindly add more funds to cover the transaction request"
+  },
+  "InsufficientGasFeeError": {
+    "plain": "More gas is needed to cover the fees for the transaction, Kindly add more funds to cover the fees."
+  },
+  "InsufficientInputAmountError": {
+    "plain": "Due to the provider's parameters, kindly add more funds to cover the transaction request."
+  },
+  "InternalError": {
+    "plain": "There is an unknown issue, Please try again at a later time, If the problem persists, get in touch with support on discord with errorId: %{errorId}"
+  },
+  "LowSpeedupFeeError": {
+    "plain": "suggestions"
+  },
+  "PairNotSupportedError": {
+    "plain": "Due to the provider's parameters, this swap pair is not available now, Kindly select a different swap provider."
+  },
+  "ThirdPartyError": {
+    "plain": {
+      "swap": "There is an unknown issue with the provider's service, Please select a different swap provider, try again at a later time.",
+      "unknown": "Kindly try again at a later time while the provider fixes this issue"
+    }
+  },
+  "UnknownError": {
+    "plain": "There is an unknown issue, please try again at a later time, In the event the issue persists, please contact support on discord with errorId: %{errorId}"
+  },
+  "SlippageTooHighError": {
+    "plain": "Please try again (Slippage is too high)"
+  },
+  "PasswordError": {
+    "plain": "Please Try Again (Password should have 8 or more characters)"
+  },
+  "NoTipError": {
+    "plain": "Please set up the miner tip greater than 0 GWEI"
+  },
+  "VeryLowTipError": {
+    "plain": "Please use the 'Low' option. (Miner tip is extremely low)"
+  },
+  "VeryHighTipWarning": {
+    "plain": "Please use the 'High' option. (Miner tip was higher than necessary)"
+  },
+  "VeryLowMaxFeeError": {
+    "plain": "Please review the 'Max Fee' value set. (The fee must be set higher)"
+  },
+  "VeryHighMaxFeeWarning": {
+    "plain": "Please review 'Max Fee', as it is higher than necessary"
+  },
+  "DuplicateTokenSymbolError": {
+    "plain": "Token with this symbol exists"
+  },
+  "LedgerDeviceConnectionError": {
+    "plain": "Ledger device not connected,connect or reconnect your device"
+  },
+  "LedgerDappConflictError": {
+    "plain": "We weren't able to get a list of accounts. Eventually, close any other apps your Ledger is connected to, including Ledger Live, and try again."
+  },
+  "LedgerAppMismatchError": {
+    "plain": "We weren't able to get a list of accounts. Please check on the Ledger if the right app/asset was selected, or cancel and choose a different asset"
+  },
+  "LedgerDevicelockedError": {
+    "plain": "Ledger device is connected but locked, please unlock your ledger device and try again"
+  },
+  "LedgerDeviceNotupdatedError": {
+    "plain": "Update your Ledger device firmware, and all apps, including Ledger Live app to the latest versions."
+  }
+}

--- a/src/utils/localization.js
+++ b/src/utils/localization.js
@@ -1,9 +1,13 @@
-import { TRANSLATIONS, liqualityErrorStringToJson } from '@liquality/error-parser'
+import { liqualityErrorStringToJson } from '@liquality/error-parser'
 import { I18n } from 'i18n-js'
 
 export const i18n = new I18n()
 
-export const loadLocale = async (locale, namespaces = ['common', 'components', 'pages']) => {
+const LIQUALITY_ERROR_NAMESPACE = 'liquality_errors'
+export const loadLocale = async (
+  locale,
+  namespaces = ['common', 'components', 'pages', LIQUALITY_ERROR_NAMESPACE]
+) => {
   if (!i18n.translations[locale]) {
     let resources = {}
     await Promise.all(
@@ -12,7 +16,7 @@ export const loadLocale = async (locale, namespaces = ['common', 'components', '
         resources[n] = translations.default
       })
     )
-    i18n.store({ [locale]: { ...resources, ...TRANSLATIONS.walletExtension[locale] } })
+    i18n.store({ [locale]: { ...resources } })
   }
 }
 
@@ -48,7 +52,10 @@ export const Localization = {
     Vue.prototype.$tle = (error) => {
       // For translating liquality error string or liquality error objects
       const errorObj = typeof error === 'string' ? liqualityErrorStringToJson(error) : error
-      return i18n.translate(errorObj.translationKey, errorObj.data)
+      return i18n.translate(
+        `${LIQUALITY_ERROR_NAMESPACE}.${errorObj.translationKey}`,
+        errorObj.data
+      )
     }
   }
 }


### PR DESCRIPTION
What this PR does the following

1. Move error translation files from wallet core to wallet
2. Update message copy for 'pair not traded' [see context](https://linear.app/liquality/issue/COR-77#comment-edd66623)
