### PR TITLE
Change the word Cadenas to Redes in Spanish

### DIFF
--- a/src/locales/es/pages.json
+++ b/src/locales/es/pages.json
@@ -77,7 +77,7 @@
     "done": "¡Hecho!",
     "forgetAllConnections": "Olvidar todas las conexiones",
     "version": "Versión",
-    "networks": "Cadenas",
+    "networks": "Redes",
     "networksSub": "Manage custom RPC network settings.",
     "customRpcForm": {
       "networkName": "Network Name",


### PR DESCRIPTION
This change has already been done in Crowdin.